### PR TITLE
Add env setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Variables de entorno para los microservicios
+
+# Credenciales de la base de datos
+DB_USERNAME=tu_usuario
+DB_PASSWORD=tu_contrasena
+
+# Credenciales de AWS para el microservicio de productos
+CLOUD_AWS_ACCESS_KEY=tu_access_key
+CLOUD_AWS_SECRET_KEY=tu_secret_key
+CLOUD_AWS_REGION=tu_region
+AWS_S3_BUCKET=tu_bucket

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.iml
 *.idea/
 .DS_Store
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Shein
 Inventario para Shein
+
+## Variables de entorno
+Para ejecutar los microservicios es necesario definir varias variables de entorno. Se incluye el archivo `.env.example` como plantilla.
+
+1. Copia este archivo y crea uno llamado `.env` en la raíz del proyecto:
+   
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edita `.env` y reemplaza los valores de ejemplo con tus credenciales reales.
+3. Antes de iniciar los servicios, carga las variables en tu terminal:
+
+   ```bash
+   set -a
+   source .env
+   set +a
+   ```
+
+De esta forma Spring Boot tomará las variables al arrancar cada microservicio.


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder variables
- ignore user `.env` files
- document how to load env vars for the microservices

## Testing
- `mvn -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68674ea10af08329893f2c186b939d4a