### PR TITLE
Add context loading tests for modules

### DIFF
--- a/micro_categoria/pom.xml
+++ b/micro_categoria/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_categoria/src/test/java/shein/micro_categoria/MicroCategoriaApplicationTests.java
+++ b/micro_categoria/src/test/java/shein/micro_categoria/MicroCategoriaApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_categoria;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroCategoriaApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_color/pom.xml
+++ b/micro_color/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_color/src/test/java/shein/micro_color/MicroColorApplicationTests.java
+++ b/micro_color/src/test/java/shein/micro_color/MicroColorApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_color;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroColorApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_correopedido/pom.xml
+++ b/micro_correopedido/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_correopedido/src/test/java/shein/micro_correopedido/MicroCorreoPedidoApplicationTests.java
+++ b/micro_correopedido/src/test/java/shein/micro_correopedido/MicroCorreoPedidoApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_correopedido;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroCorreoPedidoApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_estado/pom.xml
+++ b/micro_estado/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_estado/src/test/java/shein/micro_estado/MicroEstadoApplicationTests.java
+++ b/micro_estado/src/test/java/shein/micro_estado/MicroEstadoApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_estado;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroEstadoApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_genero/pom.xml
+++ b/micro_genero/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_genero/src/test/java/shein/micro_productos/MicroGeneroApplicationTests.java
+++ b/micro_genero/src/test/java/shein/micro_productos/MicroGeneroApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_productos;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroGeneroApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_pedido/pom.xml
+++ b/micro_pedido/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_pedido/src/test/java/shein/micro_productos/MicroPedidoApplicationTests.java
+++ b/micro_pedido/src/test/java/shein/micro_productos/MicroPedidoApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_productos;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroPedidoApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_productos/pom.xml
+++ b/micro_productos/pom.xml
@@ -90,6 +90,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_productos/src/test/java/shein/micro_productos/MicroProductosApplicationTests.java
+++ b/micro_productos/src/test/java/shein/micro_productos/MicroProductosApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_productos;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroProductosApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_subcategoria/pom.xml
+++ b/micro_subcategoria/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_subcategoria/src/test/java/shein/micro_productos/MicroSubcategoriaApplicationTests.java
+++ b/micro_subcategoria/src/test/java/shein/micro_productos/MicroSubcategoriaApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_productos;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroSubcategoriaApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/micro_talla/pom.xml
+++ b/micro_talla/pom.xml
@@ -83,6 +83,11 @@
             <version>6.1.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/micro_talla/src/test/java/shein/micro_talla/MicroTallaApplicationTests.java
+++ b/micro_talla/src/test/java/shein/micro_talla/MicroTallaApplicationTests.java
@@ -1,0 +1,10 @@
+package shein.micro_talla;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MicroTallaApplicationTests {
+    @Test
+    void contextLoads() {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
                         <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.2.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
## Summary
- add surefire plugin to parent pom
- depend on spring-boot-starter-test for each module
- create context load tests for each Spring Boot app

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68681e6b44b48329abd95583b1f86999